### PR TITLE
Fix `ttl_in_seconds`=`0` so that it will never expire

### DIFF
--- a/lib/money/bank/currencylayer_bank.rb
+++ b/lib/money/bank/currencylayer_bank.rb
@@ -155,7 +155,7 @@ class Money
       # Check if rates are expired
       # @return [Boolean] true if rates are expired
       def expired?
-        Time.now > rates_expiration
+        ttl_in_seconds == 0 ? false : Time.now > rates_expiration
       end
 
       # Check if rates are stale

--- a/lib/money/bank/currencylayer_bank.rb
+++ b/lib/money/bank/currencylayer_bank.rb
@@ -155,7 +155,7 @@ class Money
       # Check if rates are expired
       # @return [Boolean] true if rates are expired
       def expired?
-        ttl_in_seconds == 0 ? false : Time.now > rates_expiration
+        ttl_in_seconds.zero? ? false : Time.now > rates_expiration
       end
 
       # Check if rates are stale

--- a/test/currencylayer_bank_test.rb
+++ b/test/currencylayer_bank_test.rb
@@ -289,7 +289,7 @@ describe Money::Bank::CurrencylayerBank do
         subject.ttl_in_seconds = 0
         subject.update_rates
         subject.add_rate('USD', 'EUR', @old_usd_eur_rate)
-      end 
+      end
 
       it 'should not update the rates' do
         Timecop.freeze(subject.rates_timestamp + 1001) do


### PR DESCRIPTION
The readme says that the default `ttl_in_seconds` setting will never expire. The default setting is 0, and with no special handling it would expire immediately instead of never.

I tried to match the existing spec styles. Let me know if anything else should be updated.