### PR TITLE
Fix: Error handling

### DIFF
--- a/lib/money/bank/currencylayer_bank.rb
+++ b/lib/money/bank/currencylayer_bank.rb
@@ -268,11 +268,18 @@ class Money
       # @param straight [Boolean] true for straight, default is careful
       # @return [Hash] key is country code (ISO 3166-1 alpha-3) value Float
       def exchange_rates(straight = false)
-        @rates = if straight
-                   raw_rates_straight['quotes']
-                 else
-                   raw_rates_careful['quotes']
-                 end
+        rates = if straight
+                  raw_rates_straight
+                else
+                  raw_rates_careful
+                end
+        if rates.key?('quotes')
+         @rates = rates['quotes']
+        elsif rates.key?('error')
+          raise Error.new(rates.dig('error', 'info'))
+        else
+          raise Error.new('Unknown situation')
+        end
       end
 
       # Get raw exchange rates from cache and then from url


### PR DESCRIPTION
Fixes https://github.com/phlegx/money-currencylayer-bank/issues/8

Issue could be caused by API response such as:
```
{"success"=>false, "error"=>{"code"=>106, "info"=>"You have exceeded the maximum rate limitation allowed on your subscription plan. Please refer to the \"Rate Limits\" section of the API Documentation for details. "}}
```