### PR TITLE
Support source-to-source conversion in update_rates

### DIFF
--- a/lib/money/bank/currencylayer_bank.rb
+++ b/lib/money/bank/currencylayer_bank.rb
@@ -126,6 +126,13 @@ class Money
           add_rate(source, currency, rate)
           add_rate(currency, source, 1.0 / rate)
         end
+
+        # Update the rates hash with the source-source key to match the existing pattern
+        rates["#{source}#{source}"] = 1.0
+      
+        # Register the conversion for source to source
+        add_rate(source, source, 1.0)
+
         @rates_mem_timestamp = rates_timestamp
         rates
       end


### PR DESCRIPTION
**Context**
Currently, the `update_rates` method relies entirely on the API response, which typically excludes the source currency itself (e.g., it provides `USDAED`, `USDGBP`, but not `USDUSD`). As a result, the bank is unable to perform conversions where the source and destination currencies are the same (e.g., converting USD to USD), and the returned `rates` hash is missing this entry.

**Changes**
This PR explicitly appends the source currency to the `rates` hash and the internal store after the API loop finishes.

* Adds `rates["#{source}#{source}"] = 1.0` (e.g., `"USDUSD"`) to match the API's key format.
* Calls `add_rate(source, source, 1.0)` to ensure the bank correctly handles self-conversion.

**Result**

* `update_rates` now returns a hash that includes the source currency.
* `exchange_with(Money.new(100, 'USD'), 'USD')` will now work correctly instead of failing or relying on fallbacks.
